### PR TITLE
update filename regex to include numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ All notable changes to the "spectre" extension will be documented in this file.
 
 - 1.0.3: Update README and image paths
 - 1.0.4: Add repository to package.json
-- 1.0.5 Add commands to run test on the currently opened test file, or it's associated file - in either normal or watch mode
-- 1.0.6 Add command to open mock file for code/spec file
-- 1.0.7
+- 1.0.5: Add commands to run test on the currently opened test file, or it's associated file - in either normal or watch mode
+- 1.0.6: Add command to open mock file for code/spec file
+- 1.0.7:
   - Make default test commands `pnpm test` and `pnpm test-watch`
   - Give the option for a user to set different test commands in their repo's `.vscode/settings.json` file
   - Support `js` and `jsx` files
   - Watch mode now works more consistently across multiple package managers (npm, pnpm, yarn etc)
-
+- 1.0.8: Add number support to the filename regex

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,7 @@
 const vscode = require('vscode');
 const fs = require('fs');
 
-const fileNameRegex = /\/([a-zA-Z]*).(ts|tsx|js|jsx)$/;
+const fileNameRegex = /\/([a-zA-Z0-9]*).(ts|tsx|js|jsx)$/;
 
 async function openFileWithFallback(filePath, fileName) {
   vscode.window.showTextDocument(vscode.Uri.file(filePath), { preview: false }).then(() => { }, async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spectre",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spectre",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "devDependencies": {
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "VSCode command to open your spec files",
   "icon": "assets/spectre_logo.png",
   "publisher": "JaredCorker",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "engines": {
     "vscode": "^1.80.0"
   },


### PR DESCRIPTION
## Context / Reason for the change

- Add number support to the filename regex

## Documentation

- [x] Meaningful commit messages
- [x] Update CHANGELOG
- [ ] Update README
- [x] Update version number in `package.json` (run `npm i` to update `package-lock.json` version too)

## Testing

- [x] Tested locally
